### PR TITLE
Add support to list targets of a database via CLI

### DIFF
--- a/polypyus/cli.py
+++ b/polypyus/cli.py
@@ -118,10 +118,10 @@ def _cli_list(
         binary_list: Iterable[Binary], is_annotated: Optional[bool] = False
     ) -> Iterable[dict]:
 
-        ignore_keys = ["is_target", "partitions", "raw"]
+        keys = ["id", "name", "filepath"]
         data = []
         for binary in list(binaries):
-            b_dict = binary.to_dict(exclude=ignore_keys)
+            b_dict = binary.to_dict(only=keys)
             if is_annotated is True:
                 b_dict["#annotations"] = binary.annotations.count()
                 b_dict["#functions"] = binary.functions.count()

--- a/polypyus/cli.py
+++ b/polypyus/cli.py
@@ -12,7 +12,6 @@ from typing import Callable, Iterable, List, Optional
 import typer
 from loguru import logger
 from pony import orm  # type: ignore
-from pandas import DataFrame
 from tabulate import tabulate
 
 from polypyus.actions import (
@@ -117,26 +116,24 @@ def _cli_list(
 ):
     def format_binary_list(
         binary_list: Iterable[Binary], is_annotated: Optional[bool] = False
-    ) -> DataFrame:
+    ) -> Iterable[dict]:
 
         ignore_keys = ["is_target", "partitions", "raw"]
         data = []
         for binary in list(binaries):
-            b_dict = binary.to_dict()
+            b_dict = binary.to_dict(exclude=ignore_keys)
             if is_annotated is True:
                 b_dict["#annotations"] = binary.annotations.count()
                 b_dict["#functions"] = binary.functions.count()
             data.append(b_dict)
 
-        df = DataFrame(data)
-        df = df.drop(ignore_keys, axis=1)
-        return df
+        return data
 
     if list_history is True:
         typer.echo("History Files")
         binaries = Binary.select_annotated()
         formatted = format_binary_list(binaries, is_annotated=True)
-        table = tabulate(formatted, headers=formatted.columns, showindex=False)
+        table = tabulate(formatted, headers="keys")
         typer.echo(table)
 
     if list_history is True and list_targets is True:
@@ -146,7 +143,7 @@ def _cli_list(
         typer.echo("Target Files")
         binaries = Binary.select_unannotated()
         formatted = format_binary_list(binaries, is_annotated=False)
-        table = tabulate(formatted, headers=formatted.columns, showindex=False)
+        table = tabulate(formatted, headers="keys")
         typer.echo(table)
 
 

--- a/polypyus/cli.py
+++ b/polypyus/cli.py
@@ -112,7 +112,8 @@ def _analyze(
 @orm.db_session
 @logger.catch
 def _cli_list(
-    list_history: bool, list_targets: bool,
+    list_history: bool,
+    list_targets: bool,
 ):
     def format_binary_list(
         binary_list: Iterable[Binary], is_annotated: Optional[bool] = False
@@ -123,8 +124,8 @@ def _cli_list(
         for binary in list(binaries):
             b_dict = binary.to_dict()
             if is_annotated is True:
-                b_dict["#annotations"] = len(binary.annotations)
-                b_dict["#functions"] = len(binary.annotations.functions)
+                b_dict["#annotations"] = binary.annotations.count()
+                b_dict["#functions"] = binary.functions.count()
             data.append(b_dict)
 
         df = DataFrame(data)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(
         "loguru == 0.4.*",
         "tabulate == 0.8.*",
         "dataclasses",
-        "pandas"
     ],
     tests_require=test_deps,
     extras_require={"development": ["PyQt5-stubs == 5.*", "pylama"], "test": test_deps},

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         "loguru == 0.4.*",
         "tabulate == 0.8.*",
         "dataclasses",
+        "pandas"
     ],
     tests_require=test_deps,
     extras_require={"development": ["PyQt5-stubs == 5.*", "pylama"], "test": test_deps},


### PR DESCRIPTION
This pr adds ` --list-history` and `--list-targets` flags to the CLI interface. 

It uses pandas to format the Binary metadata, hence the additional requirement in setup.py.

I hope you are okay that the `format_binary_list` function is inlined in `_cli_list` - I tried adding it to `tools.py` first, but unfortunately, that breaks type annotations for `Iterable[Binary]`, due to circular imports. Hence, I hope that you are alright with the current solution. :)

Cheers,
Marius