### PR TITLE
ghidra importer and exporter for 32bit ARM csv's

### DIFF
--- a/import_export/ghidra/ghidra_export_pp.py
+++ b/import_export/ghidra/ghidra_export_pp.py
@@ -1,0 +1,56 @@
+# Script to export polypus csv data
+
+# @category Polypyus
+
+import csv
+
+functionManager = currentProgram.getFunctionManager()
+
+
+def write_csv(csvfile, symbols):
+
+    with open(csvfile, "w") as file:
+        fieldnames = ["name", "addr", "size", "mode", "type"]
+        writer = csv.DictWriter(file, delimiter=" ", fieldnames=fieldnames)
+
+        writer.writeheader()
+        for symbol in symbols:
+            writer.writerow(symbol)
+
+
+# https://github.com/NationalSecurityAgency/ghidra/issues/1132
+def isThumbFunction(func):
+    r = currentProgram.getRegister("TMode")
+    value = currentProgram.programContext.getRegisterValue(r, func.entryPoint)
+    return value.unsignedValueIgnoreMask == 1
+
+
+def get_symbols():
+    symbols = []
+
+    funcs = functionManager.getFunctions(True)
+    for func in funcs:
+        symbol = {}
+        symbol["name"] = func.getName()
+        symbol["addr"] = hex(int(str(func.getEntryPoint()), 16))
+        symbol["size"] = func.getBody().getNumAddresses()
+
+        if isThumbFunction(func) is True:
+            symbol["mode"] = "THUMB_32"
+        else:
+            symbol["mode"] = "ARM_32"
+
+        symbol["type"] = "FUNC"
+        symbols.append(symbol)
+
+    return symbols
+
+
+language = currentProgram.getLanguage()
+if language.getProcessor == "ARM" or language.getLanguageDescription().getSize() == 32:
+    csv_file = str(askFile("Choose Polypyus export CSV", "Select"))
+    symbols = get_symbols()
+    write_csv(csv_file, symbols)
+    print("Successfully exported symbols to {}".format(csv_file))
+else:
+    print("PP-Ghidra only supports 32-bit ARM binaries!")

--- a/import_export/ghidra/ghidra_import_pp.py
+++ b/import_export/ghidra/ghidra_import_pp.py
@@ -1,0 +1,83 @@
+# Script to import polypus csv data
+
+# @category Polypyus
+
+import csv
+
+from ghidra.app.cmd.disassemble import ArmDisassembleCommand
+
+OVERWRITE_EXISTING = False
+
+
+functionManager = currentProgram.getFunctionManager()
+addr_factory = currentProgram.getAddressFactory()
+
+
+def read_csv(csv_file):
+    """
+    Returns a dict with the polypypus data
+    """
+    symbols = []
+    with open(csv_file, "r") as file:
+        fieldnames = ["name", "addr", "size", "mode", "type"]
+        reader = csv.DictReader(file, delimiter=" ", fieldnames=fieldnames)
+
+        for row in reader:
+            symbols.append(row)
+
+    return symbols
+
+
+def create_function_from_pp(symbol):
+    """
+    Takes
+    """
+    name = symbol["name"]
+    size = symbol["size"]
+    mode = symbol["mode"]
+
+    start = toAddr(int(symbol["addr"], 16))
+    end = toAddr(int(symbol["addr"], 16) + int(symbol["size"]))
+
+    func = functionManager.getFunctionAt(start)
+
+    if func is not None:
+        if OVERWRITE_EXISTING is True:
+            removeFunction(func)
+        else:
+            return False
+
+    func = createFunction(start, name)
+    if func is None:
+        return False
+
+    addr_set = addr_factory.getAddressSet(start, end)
+    func.body.add(addr_set)
+    is_thumb = True if mode == "THUMB_32" else False
+
+    disas = ArmDisassembleCommand(start, addr_set, is_thumb)
+    disas.enableCodeAnalysis(False)
+    disas.applyTo(currentProgram)
+
+    return True
+
+
+def apply_symbols(symbols):
+    for symbol in symbols:
+        if symbol["type"] == "FUNC":
+            if create_function_from_pp(symbol) is True:
+                print("{}: Successfully created function".format(symbol["name"]))
+            else:
+                print("{}: Function generation failed".format(symbol["name"]))
+
+        else:
+            print("{}: type {} not supported".format(symbol["name"], symbol["type"]))
+
+
+language = currentProgram.getLanguage()
+if language.getProcessor == "ARM" or language.getLanguageDescription().getSize() == 32:
+    csv_file = str(askFile("Choose Polypyus CSV", "Select"))
+    symbols = read_csv(csv_file)
+    apply_symbols(symbols)
+else:
+    print("PP-Ghidra only supports 32-bit ARM binaries!")


### PR DESCRIPTION
Import and export is tested with the binaries/csv's from your firmware/history folder.
Ghidra slightly changes the lengths of functions after import, probably due to autoanalysis, but overall, both import and export seem to produce correct results.

As stated in #7 the delimiter to use was a bit ambiguous, however, I decided to go for `' '`, as this is done for most of the other scripts as well.

Cheers,
Marius