### PR TITLE
Fix variable "matchers" referenced before assignment in polypyus/cli.py

### DIFF
--- a/polypyus/cli.py
+++ b/polypyus/cli.py
@@ -65,6 +65,7 @@ def prepare_graph(
         typer.echo("No history entries in database")
         return None
 
+    matchers = None
     if histories:
         logger.debug("Clearing matchers")
         Matcher.reset()


### PR DESCRIPTION
I wanted to reproduce the example in [Using the CLI](https://github.com/seemoo-lab/polypyus#using-the-cli) but I found the following bug in `prepare_graph()`. The little patch proposed in the pull request solve the issue.

```text
$ polypyus-cli \
  --history firmware/history/20819-A1.bin \
  --annotation firmware/history/20819-A1_patch.elf \
  --history firmware/history/20735B1.bin \
  --annotation firmware/history/20735B1_patch.elf \
  --project test.sqlite

$ polypyus-cli \
  --target firmware/history/20739B1.bin \
  --project test.sqlite

2023-04-07 09:48:39.455 | ERROR    | pony.orm.core:new_func:519 - An error has been caught in function 'new_func', process 'MainProcess' (63209), thread 'MainThread' (140525582792512):
Traceback (most recent call last):

  File "/home/henderson/env_patch_poly/bin/polypyus-cli", line 33, in <module>
    sys.exit(load_entry_point('polypyus', 'console_scripts', 'polypyus-cli')())
    │   │    └ <function importlib_load_entry_point at 0x7fcea92bf130>
    │   └ <built-in function exit>
    └ <module 'sys' (built-in)>
  File "/home/henderson/env_patch_poly/lib/python3.10/site-packages/typer/main.py", line 214, in __call__
    return get_command(self)(*args, **kwargs)
           │           │      │       └ {}
           │           │      └ ()
           │           └ <typer.main.Typer object at 0x7fcea8e8de10>
           └ <function get_command at 0x7fcea8c053f0>
  File "/home/henderson/env_patch_poly/lib/python3.10/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
           │    │     │       └ {}
           │    │     └ ()
           │    └ <function BaseCommand.main at 0x7fcea8da4a60>
           └ <TyperCommand analyze>
  File "/home/henderson/env_patch_poly/lib/python3.10/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
         │    │      └ <click.core.Context object at 0x7fcea7df0b20>
         │    └ <function Command.invoke at 0x7fcea8da53f0>
         └ <TyperCommand analyze>
  File "/home/henderson/env_patch_poly/lib/python3.10/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           │   │      │    │           │   └ {'target': ('firmware/history/20739B1.bin',), 'project': 'test.sqlite', 'verbose': 0, 'history': (), 'annotation': (), 'paral...
           │   │      │    │           └ <click.core.Context object at 0x7fcea7df0b20>
           │   │      │    └ <function analyze at 0x7fcea7dea050>
           │   │      └ <TyperCommand analyze>
           │   └ <function Context.invoke at 0x7fcea8da4550>
           └ <click.core.Context object at 0x7fcea7df0b20>
  File "/home/henderson/env_patch_poly/lib/python3.10/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
           │         │       └ {'target': ('firmware/history/20739B1.bin',), 'project': 'test.sqlite', 'verbose': 0, 'history': (), 'annotation': (), 'paral...
           │         └ ()
           └ <function analyze at 0x7fcea7dea050>
  File "/home/henderson/env_patch_poly/lib/python3.10/site-packages/typer/main.py", line 497, in wrapper
    return callback(**use_params)  # type: ignore
           │          └ {'verbose': 0, 'history': [], 'annotation': [], 'target': [PosixPath('firmware/history/20739B1.bin')], 'parallelize': False, ...
           └ <function analyze at 0x7fcea7de9d80>

  File "/home/henderson/polypyus/polypyus/cli.py", line 34, in inner
    res = f(*args, **kwargs)
          │  │       └ {'verbose': 0, 'history': [], 'annotation': [], 'target': [PosixPath('firmware/history/20739B1.bin')], 'parallelize': False, ...
          │  └ ()
          └ <function analyze at 0x7fcea7de9cf0>

  File "/home/henderson/polypyus/polypyus/cli.py", line 197, in analyze
    _analyze(history, annotation, target, parallelize, min_size, max_rel_fuzz)
    │        │        │           │       │            │         └ 0.5
    │        │        │           │       │            └ 28
    │        │        │           │       └ False
    │        │        │           └ [PosixPath('firmware/history/20739B1.bin')]
    │        │        └ []
    │        └ []
    └ <function _analyze at 0x7fcea7de97e0>

  File "<string>", line 2, in _analyze
> File "/home/henderson/env_patch_poly/lib/python3.10/site-packages/pony/orm/core.py", line 519, in new_func
    result = func(*args, **kwargs)
             │     │       └ {}
             │     └ ([], [], [PosixPath('firmware/history/20739B1.bin')], False, 28, 0.5)
             └ <function _analyze at 0x7fcea7de93f0>

  File "/home/henderson/polypyus/polypyus/cli.py", line 102, in _analyze
    graph = prepare_graph(history, annotation, min_size, max_rel_fuzz)
            │             │        │           │         └ 0.5
            │             │        │           └ 28
            │             │        └ []
            │             └ []
            └ <function prepare_graph at 0x7fcea7de9000>

  File "/home/henderson/polypyus/polypyus/cli.py", line 77, in prepare_graph
    graph = makeGraph(matchers)
            └ <function makeGraph at 0x7fcea7de84c0>

UnboundLocalError: local variable 'matchers' referenced before assignment
```